### PR TITLE
[sandbox] Allow maliit by default. Fixes JB#51408

### DIFF
--- a/data/sailfish-app.profile
+++ b/data/sailfish-app.profile
@@ -33,7 +33,7 @@ dbus-system.talk com.nokia.NonGraphicFeedback1.Backend
 dbus-user filter
 dbus-user.talk ca.desrt.dconf
 dbus-user.talk com.nokia.profiled
-dbus-user.talk org.malitt.server
+dbus-user.talk org.maliit.server
 dbus-user.talk org.nemo.transferengine
 
 ### environment

--- a/src/booster-firejail.cpp
+++ b/src/booster-firejail.cpp
@@ -154,7 +154,6 @@ int FirejailBooster::launchProcess()
     }
     else {
         addArg(fullargv, "--protocol=unix,netlink");
-        addArg(fullargv, "--net=none");
     }
 
     // Data dirs


### PR DESCRIPTION
As maliit creates an abstract socket it's not visible to new namespace.
Let's not create a new namespace when there is no internet access, at
least until there is a better solution.

In any case we do not create a network namespace if networking is
allowed.

Fix that typo in sailfish-app.profile, which is also required to allow maliit to work.