### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/mapplauncherd-booster-firejail.spec
+++ b/rpm/mapplauncherd-booster-firejail.spec
@@ -5,9 +5,8 @@ Release:    1
 License:    LGPLv2.1
 URL:        https://github.org/sailfishos/mapplauncherd-booster-firejail
 Source0:    %{name}-%{version}.tar.bz2
-BuildRequires:  pkgconfig
 BuildRequires:  qt5-qmake
-BuildRequires:  systemd
+BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(applauncherd) >= 4.2.3
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(gio-2.0)


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>